### PR TITLE
Improve Fact_SchoolPrincipal

### DIFF
--- a/create_Fact_PrincipalMobility.sql
+++ b/create_Fact_PrincipalMobility.sql
@@ -11,7 +11,6 @@ CREATE TABLE BaseSchoolPrincipals (
     CertificateNumber varchar(500) NULL,
     CountyAndDistrictCode varchar(500) NULL,
     Building varchar(500) NULL,
-    DutyRoot varchar(2) NULL,
     PrincipalType varchar(50) NULL
 );
 
@@ -23,7 +22,6 @@ INSERT INTO BaseSchoolPrincipals (
     CertificateNumber,
     CountyAndDistrictCode,
     Building,
-    DutyRoot,
     PrincipalType
 )
 SELECT
@@ -32,7 +30,6 @@ SELECT
     CertificateNumber,
     CountyAndDistrictCode,
     Building,
-    DutyRoot,
     PrincipalType
 FROM Fact_SchoolPrincipal sp
 JOIN Dim_Staff s
@@ -171,7 +168,6 @@ YearBrackets AS (
         -- start fields
         t1.CountyAndDistrictCode AS StartCountyAndDistrictCode,
         t1.Building AS StartBuilding,
-        t1.DutyRoot AS StartDutyRoot,
         t1.PrincipalType AS StartPrincipalType,
         -- end fields, using StaffByHighestFTE
         t2.CountyAndDistrictCode AS EndStaffByHighestFTECountyAndDistrictCode,
@@ -179,7 +175,6 @@ YearBrackets AS (
         t2.DutyRoot AS EndStaffByHighestFTEDutyRoot,
         -- end fields, using principals table
         t3.PrincipalType AS EndPrincipalType,
-        t3.DutyRoot AS EndPrincipalDutyRoot,
         -- avoid counting exiters by checking for join to a StaffByHighestFTE row to ensure they're still employed somehow;
         -- if join didn't match anything in BaseSchoolPrincipals, then person isn't a Principal or AP in endyear
         CASE WHEN t2.CertificateNumber IS NOT NULL AND t3.CertificateNumber IS NULL THEN 1 ELSE 0 END AS NoLongerAnyPrincipal
@@ -209,7 +204,7 @@ YearBrackets AS (
         ,CASE WHEN
             EndStaffByHighestFTEBuilding IS NULL
         THEN 1 ELSE 0 END AS Exited
-        ,CASE WHEN StartDutyRoot = EndPrincipalDutyRoot THEN 1 ELSE 0 END AS SameAssignment
+        ,CASE WHEN StartPrincipalType = EndPrincipalType THEN 1 ELSE 0 END AS SameAssignment
         ,CASE
             WHEN StartPrincipalType = 'AssistantPrincipal' AND EndPrincipalType = 'Principal'
         THEN 1 ELSE 0 END AS AsstToPrincipal

--- a/update_Dim_School.sql
+++ b/update_Dim_School.sql
@@ -88,6 +88,7 @@ SET
 			WHERE
 				p.PrincipalType = 'Principal'
 				AND st.PersonOfColorCategory = 'Person of Color'
+				AND p.PrimaryFlag = 1
 				AND p.AcademicYear = Dim_School.AcademicYear
 				AND st.CountyAndDistrictCode = Dim_School.DistrictCode
 				AND p.Building = Dim_School.SchoolCode
@@ -101,6 +102,7 @@ SET
 			WHERE
 				p.PrincipalType = 'AssistantPrincipal'
 				AND st.PersonOfColorCategory = 'Person of Color'
+				AND p.PrimaryFlag = 1
 				AND p.AcademicYear = Dim_School.AcademicYear
 				AND st.CountyAndDistrictCode = Dim_School.DistrictCode
 				AND p.Building = Dim_School.SchoolCode


### PR DESCRIPTION
This branch has 3 changes:

1) `Fact_SchoolPrincipal` no longer stores a DutyRoot code and no longer uses it as part of the grain, because that was creating a small number (1831) of rows with 2 different DutyRoots for the same PrincipalType. This is probably because it's an unusual school type, since the duty roots for Prin/AP are distinguished by whether it's a primary or secondary school.

    For the purposes of this table, we don't care about schooltype, only the fact that they had that role at that school. This change makes the grain of the table less confusing and easier to work with.

2) Related to the above, `Fact_PrincipalMobility` had a bug where the SameAssignment field was comparing DutyRoot when it makes more sense to compare PrincipalType. This is fixed. No analysis was using that field, so there should be no impact.

3) The PrincipalOfColorFlag and AsstPrincipalOfColorFlag fields in `Dim_School` were set to 1 if ANY principal or AP at the school was a POC. I changed this so only the "primary" (the highest FTE) principal/AP is examined. The impact to PrincipalOfColorFlag is very small: only 40 rows changed in that table, only 1 row in the RMR. For AsstPrincipalOfColorFlag, 131 rows changed, 10 rows in the RMR. No analysis was using these fields, so there should be no impact.
